### PR TITLE
fix heap use after free when terminating and pass CXXFLAGS to linker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ ENGINE_LDFLAGS = \
 all: $(GAME_BIN)
 
 $(GAME_BIN): $(GAME_OBJECTS)
-	$(CXX) $(GAME_OBJECTS) $(ENGINE_LDFLAGS) -o $@
+	$(CXX) $(CXXFLAGS) $(GAME_OBJECTS) $(ENGINE_LDFLAGS) -o $@
 	$(STRIP) $@
 
 .cpp.o: $(DEP_DIR)/%.d

--- a/game/main.cpp
+++ b/game/main.cpp
@@ -400,6 +400,6 @@ int neoMain(FrameTimer &timer, a::Audio &audio, r::World &world_, int, char **, 
         //audio.setPan(handle, direction.x);
     }
 
-    delete gWorld;
+//    delete gWorld;
     return 0;
 }


### PR DESCRIPTION
the heap use after free we had applied locally when searching for memleaks a few days ago, but I guess the change went missing somehow.

pass CXXFLAGS to the linker, when building with -fsanitize=address,undefined linking fails otherwise